### PR TITLE
allow processing of rename changesets

### DIFF
--- a/src/GitTfs/Core/GitCommit.cs
+++ b/src/GitTfs/Core/GitCommit.cs
@@ -6,7 +6,7 @@ using LibGit2Sharp;
 
 namespace GitTfs.Core
 {
-    public class GitCommit
+    public class GitCommit : IGitCommit
     {
         private readonly Commit _commit;
 

--- a/src/GitTfs/Core/GitRepository.cs
+++ b/src/GitTfs/Core/GitRepository.cs
@@ -36,7 +36,7 @@ namespace GitTfs.Core
                 _repository.Dispose();
         }
 
-        public GitCommit Commit(LogEntry logEntry)
+        public IGitCommit Commit(LogEntry logEntry)
         {
             var parents = logEntry.CommitParents.Select(sha => _repository.Lookup<Commit>(sha));
             var commit = _repository.ObjectDatabase.CreateCommit(

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -404,10 +404,12 @@ namespace GitTfs.Core
                         {
                             fetchResult.IsProcessingRenameChangeset = true;
                             fetchResult.LastParentCommitBeforeRename = MaxCommitHash;
-                            return fetchResult;
                         }
-                        renameResult.IsProcessingRenameChangeset = false;
-                        renameResult.LastParentCommitBeforeRename = null;
+                        else
+                        {
+                            renameResult.IsProcessingRenameChangeset = false;
+                            renameResult.LastParentCommitBeforeRename = null;
+                        }
                     }
                     if (parentCommitSha != null)
                         log.CommitParents.Add(parentCommitSha);

--- a/src/GitTfs/Core/IGitCommit.cs
+++ b/src/GitTfs/Core/IGitCommit.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GitTfs.Core
+{
+    public interface IGitCommit
+    {
+        Tuple<string, string> AuthorAndEmail { get; }
+        string Message { get; }
+        IEnumerable<GitCommit> Parents { get; }
+        string Sha { get; }
+        DateTimeOffset When { get; }
+
+        IEnumerable<GitTreeEntry> GetTree();
+    }
+}

--- a/src/GitTfs/Core/IGitRepository.cs
+++ b/src/GitTfs/Core/IGitRepository.cs
@@ -21,7 +21,7 @@ namespace GitTfs.Core
         bool HasRemote(string remoteId);
         bool IsInSameTeamProjectAsDefaultRepository(string tfsRepositoryPath);
         bool HasRef(string gitRef);
-        GitCommit Commit(LogEntry logEntry);
+        IGitCommit Commit(LogEntry logEntry);
         void UpdateRef(string gitRefName, string commitSha, string message = null);
         void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote);
         void MoveTfsRefForwardIfNeeded(IGitTfsRemote remote, string @ref);

--- a/src/GitTfsTest/Core/GitTfsRemoteTests.cs
+++ b/src/GitTfsTest/Core/GitTfsRemoteTests.cs
@@ -1,8 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.ServiceModel.Syndication;
+
 using GitTfs.Commands;
 using GitTfs.Core;
 using GitTfs.Core.TfsInterop;
 using GitTfs.Util;
+
 using Moq;
 using StructureMap.AutoMocking;
 using Xunit;
@@ -102,6 +107,61 @@ namespace GitTfs.Test.Core
             Assert.Null(subtreeRemote.GetPathInGitRepo("$/Project/MyBranch_other/file.txt"));
         }
 
+        [Fact]
+        public void GivenAChangeset_ShouldNotSkipNextChangesets()
+        {
+            var mockGit = SetupGit();
+            var changeset1 = new Mock<ITfsChangeset>();
+            var changeset2 = new Mock<ITfsChangeset>();
+            var changeset3 = new Mock<ITfsChangeset>();
+
+            changeset1.Setup(o => o.Summary).Returns(new TfsChangesetInfo());
+            changeset1.Setup(o => o.Apply(It.IsAny<string>(), It.IsAny<IGitTreeModifier> (), It.IsAny<ITfsWorkspace> (), It.IsAny<IDictionary<string, GitObject>>() ,It.IsAny<Action <Exception>>() )).Returns(new LogEntry());
+            changeset1.Setup(o => o.IsRenameChangeset).Returns(true);
+
+            changeset2.Setup(o => o.Summary).Returns(new TfsChangesetInfo());
+            changeset2.Setup(o => o.Apply(It.IsAny<string>(), It.IsAny<IGitTreeModifier> (), It.IsAny<ITfsWorkspace> (), It.IsAny<IDictionary<string, GitObject>>() ,It.IsAny<Action <Exception>>() )).Returns(new LogEntry());
+
+            changeset3.Setup(o => o.Summary).Returns(new TfsChangesetInfo() { ChangesetId = 2000 });
+            changeset3.Setup(o => o.Apply(It.IsAny<string>(), It.IsAny<IGitTreeModifier>(), It.IsAny<ITfsWorkspace>(), It.IsAny<IDictionary<string, GitObject>>(), It.IsAny<Action<Exception>>())).Returns(new LogEntry());
+
+            var changeSetResult = new List<ITfsChangeset>
+            {
+                changeset1.Object,
+                changeset2.Object,
+                changeset3.Object,
+            };
+            var mockWorkspace = new Mock<ITfsWorkspace>();
+
+            var fakeTfs = new FakeTfsHelper(changeSetResult, mockWorkspace.Object);
+            var globals = new Globals();
+            globals.Repository = mockGit;
+            globals.GitDir = "dir";
+
+            var loader = new ConfigPropertyLoader(globals);
+            var config = new ConfigProperties(loader);
+            var remote = new GitTfsRemote(new RemoteInfo() { Id= "abc", Repository = "repo"}, mockGit, new RemoteOptions(), globals, fakeTfs, config);
+
+            mockWorkspace.Setup(o => o.Remote).Returns(remote);
+
+            var result = remote.Fetch();
+
+            Assert.Equal(3, result.NewChangesetCount);
+        }
+
+        private IGitRepository SetupGit()
+        {
+            var mockTreeBuilder = new Mock<IGitTreeBuilder>();
+            mockTreeBuilder.Setup(o => o.GetTree());
+            var mockCommit = new Mock<IGitCommit>();
+            var mockGit = new Mock<IGitRepository>();
+            mockGit.Setup(o => o.GetConfig<int>(It.IsAny<string>())).Returns(122);
+            mockGit.Setup(o => o.GetSubtrees(It.IsAny<IGitTfsRemote>())).Returns(new List<IGitTfsRemote>());
+            mockGit.Setup(o => o.GetTreeBuilder(It.IsAny<string>())).Returns(mockTreeBuilder.Object);
+            mockGit.Setup(o => o.Commit(It.IsAny<LogEntry>())).Returns(mockCommit.Object);
+            return mockGit.Object;
+        }
+
         private GitTfsRemote BuildSubTreeOwnerRemote(IEnumerable<IGitTfsRemote> remotes)
         {
             var info = new RemoteInfo
@@ -119,6 +179,165 @@ namespace GitTfs.Test.Core
 
             mocks.Inject(new Globals() { Repository = mockGitRepository.Object });
             return mocks.ClassUnderTest;
+        }
+    }
+
+    public class FakeTfsHelper : ITfsHelper
+    {
+        List<ITfsChangeset> _changesets;
+        ITfsWorkspace _workspace;
+        public FakeTfsHelper(List<ITfsChangeset> changesets, ITfsWorkspace workspace)
+        {
+            _changesets = changesets;
+            _workspace = workspace;
+        }
+
+        public string TfsClientLibraryVersion => throw new NotImplementedException();
+
+        public string Url { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+
+        public bool CanShowCheckinDialog => throw new NotImplementedException();
+
+        public void CleanupWorkspaces(string workingDirectory)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CreateBranch(string sourcePath, string targetPath, int changesetId, string comment = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICheckinNote CreateCheckinNote(Dictionary<string, string> checkinNotes)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IShelveset CreateShelveset(IWorkspace workspace, string shelvesetName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CreateTfsRootBranch(string projectName, string mainBranch, string gitRepositoryPath, bool createTeamProjectFolder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void DeleteShelveset(IWorkspace workspace, string shelvesetName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void EnsureAuthenticated()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int FindMergeChangesetParent(string path, int firstChangeset, GitTfsRemote remote)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<string> GetAllTfsRootBranchesOrderedByCreation()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IBranchObject> GetBranches(bool getDeletedBranches = false)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ITfsChangeset GetChangeset(int changesetId, IGitTfsRemote remote)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IChangeset GetChangeset(int changesetId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<ITfsChangeset> GetChangesets(string path, int startVersion, IGitTfsRemote remote, int lastVersion = -1, bool byLots = false)
+        {
+            return _changesets;
+        }
+
+        public IIdentity GetIdentity(string username)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<TfsLabel> GetLabels(string tfsPathBranch, string nameFilter = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ITfsChangeset GetLatestChangeset(IGitTfsRemote remote)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int GetLatestChangesetId(IGitTfsRemote remote)
+        {
+            return 122;
+        }
+
+        public IList<RootBranch> GetRootChangesetForBranch(string tfsPathBranchToCreate, int lastChangesetIdToCheck = -1, string tfsPathParentBranch = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ITfsChangeset GetShelvesetData(IGitTfsRemote remote, string shelvesetOwner, string shelvesetName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IWorkItemCheckedInfo> GetWorkItemCheckedInfos(IEnumerable<string> workItems, TfsWorkItemCheckinAction checkinAction)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IWorkItemCheckinInfo> GetWorkItemInfos(IEnumerable<string> workItems, TfsWorkItemCheckinAction checkinAction)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasShelveset(string shelvesetName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsExistingInTfs(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int ListShelvesets(ShelveList shelveList, IGitTfsRemote remote)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int QueueGatedCheckinBuild(Uri value, string buildDefinitionName, string shelvesetName, string checkInTicket)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int ShowCheckinDialog(IWorkspace workspace, IPendingChange[] pendingChanges, IEnumerable<IWorkItemCheckedInfo> checkedInfos, string checkinComment)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WithWorkspace(string directory, IGitTfsRemote remote, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action)
+        {
+            action(_workspace);
+        }
+
+        public void WithWorkspace(string localDirectory, IGitTfsRemote remote, IEnumerable<Tuple<string, string>> mappings, TfsChangesetInfo versionToFetch, Action<ITfsWorkspace> action)
+        {
+            action(_workspace);
         }
     }
 }


### PR DESCRIPTION
Currently, git-tfs clones up until it reaches a rename changeset, and then exits without any information or warning. This results in a partially cloned branch where the latest commit is the commit before the rename.

My fix is to merely continue after we've reached a rename changeset, which will apply the rename changeset as a commit to git. I believe this is the correct behaviour, as it captures the rename changeset as a commit, but also processes subsequent changesets